### PR TITLE
Feat/analytics

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model College {
     updatedAt DateTime    @updatedAt
     Users     User[]
     type      CollegeType @default(ENGINEERING)
+    championshipPoints Int @default(0)
 }
 
 model Branch {
@@ -112,6 +113,7 @@ model Event {
     Teams            Team[]
     Rounds           Round[]
     category         EventCategory      @default(TECHNICAL)
+    tier             EventTier          @default(GOLD)
     Winner           Winners[]
     CertificateIssue CertificateIssue[]
     Level            Level[]
@@ -549,6 +551,13 @@ enum EventCategory {
     NON_TECHNICAL
     CORE
     SPECIAL
+}
+
+enum EventTier {
+    DIAMOND
+    GOLD
+    SILVER
+    BRONZE
 }
 
 enum CollegeType {

--- a/src/graphql/models/PaymentOrder/index.ts
+++ b/src/graphql/models/PaymentOrder/index.ts
@@ -2,6 +2,7 @@ import { PaymentType, Status } from "@prisma/client";
 
 import { builder } from "~/graphql/builder";
 import "~/graphql/models/PaymentOrder/mutation";
+import "~/graphql/models/PaymentOrder/query";
 
 builder.enumType(PaymentType, {
   name: "PaymentType",

--- a/src/graphql/models/PaymentOrder/query.ts
+++ b/src/graphql/models/PaymentOrder/query.ts
@@ -1,0 +1,21 @@
+import { builder } from "~/graphql/builder";
+
+builder.queryField("getRevenue", (t) =>
+  t.int({
+    errors: {
+      types: [Error],
+    },
+    resolve: async (query, args, ctx, info) => {
+      const revenue = await ctx.prisma.paymentOrder.aggregate({
+        _sum: {
+          amount: true,
+        },
+        where: {
+          AND: [{ type: "FEST_REGISTRATION" }, { status: "SUCCESS" }],
+        },
+      });
+
+      return revenue._sum.amount ?? 0;
+    },
+  }),
+);

--- a/src/graphql/models/ProniteRegistration/index.ts
+++ b/src/graphql/models/ProniteRegistration/index.ts
@@ -2,6 +2,7 @@ import { ProniteDay } from "@prisma/client";
 
 import { builder } from "~/graphql/builder";
 import "~/graphql/models/ProniteRegistration/mutation";
+import "~/graphql/models/ProniteRegistration/query";
 
 builder.enumType(ProniteDay, {
   name: "ProniteDay",

--- a/src/graphql/models/ProniteRegistration/query.ts
+++ b/src/graphql/models/ProniteRegistration/query.ts
@@ -1,0 +1,37 @@
+import { builder } from "~/graphql/builder";
+
+class ProniteRegistrationCounts {
+  day1Count: number;
+  day2Count: number;
+  constructor(day1Count: number, day2Count: number) {
+    this.day1Count = day1Count;
+    this.day2Count = day2Count;
+  }
+}
+
+const proniteCount = builder.objectType(ProniteRegistrationCounts, {
+  name: "ProniteRegistrationCounts",
+  fields: (t) => ({
+    day1Count: t.exposeInt("day1Count"),
+    day2Count: t.exposeInt("day2Count"),
+  }),
+});
+
+builder.queryField("getProniteRegistrations", (t) =>
+  t.field({
+    type: proniteCount,
+    resolve: async (root, args, ctx, info) => {
+      const day1Count = await ctx.prisma.proniteRegistration.count({
+        where: {
+          proniteDay: "Day1",
+        },
+      });
+      const day2Count = await ctx.prisma.proniteRegistration.count({
+        where: {
+          proniteDay: "Day2",
+        },
+      });
+      return { day1Count, day2Count };
+    },
+  }),
+);

--- a/src/graphql/models/Team/mutation.ts
+++ b/src/graphql/models/Team/mutation.ts
@@ -700,7 +700,7 @@ builder.mutationField("organizerAddTeamMember", (t) =>
       ) {
         throw new Error("Not authorized");
       }
-      if (!(user.College?.type === "ENGINEERING")) {
+      if (!(participant.College?.type === "ENGINEERING")) {
         if (
           !(await canRegister(
             participant.id,

--- a/src/graphql/models/Winner/query.ts
+++ b/src/graphql/models/Winner/query.ts
@@ -1,4 +1,6 @@
 import { builder } from "~/graphql/builder";
+import { prisma } from "~/utils/db";
+import { checkChampionshipEligibility } from "./utils";
 
 builder.queryField("winnersByEvent", (t) =>
   t.prismaField({
@@ -38,6 +40,182 @@ builder.queryField("allWinners", (t) =>
       return ctx.prisma.winners.findMany({
         ...query,
       });
+    },
+  }),
+);
+
+class CountClass {
+  WINNER: number;
+  RUNNER_UP: number;
+  SECOND_RUNNER_UP: number;
+  constructor(WINNER: number, RUNNER_UP: number, SECOND_RUNNER_UP: number) {
+    this.WINNER = WINNER;
+    this.RUNNER_UP = RUNNER_UP;
+    this.SECOND_RUNNER_UP = SECOND_RUNNER_UP;
+  }
+}
+
+class ChampionshipPointsClass {
+  collegeId: number;
+  collegeName: string;
+  championshipPoints: number;
+  techCount: number;
+  nonTechCount: number;
+  coreCount: number;
+  diamondCount: CountClass;
+  goldCount: CountClass;
+  silverCount: CountClass;
+  bronzeCount: CountClass;
+  isEligible: boolean;
+  constructor(
+    collegeId: number,
+    isEligible: boolean,
+    championshipPoints: number,
+    collegeName: string,
+    techCount: number,
+    nonTechCount: number,
+    coreCount: number,
+    goldCount: CountClass,
+    diamondCount: CountClass,
+    silverCount: CountClass,
+    bronzeCount: CountClass,
+  ) {
+    this.collegeName = collegeName;
+    this.isEligible = isEligible;
+    this.collegeId = collegeId;
+    this.championshipPoints = championshipPoints;
+    this.diamondCount = diamondCount;
+    this.techCount = techCount;
+    this.nonTechCount = nonTechCount;
+    this.coreCount = coreCount;
+    this.goldCount = goldCount;
+    this.silverCount = silverCount;
+    this.bronzeCount = bronzeCount;
+  }
+}
+
+const Count = builder.objectType(CountClass, {
+  name: "Counts",
+  fields: (t) => ({
+    winner: t.exposeInt("WINNER"),
+    runner_up: t.exposeInt("RUNNER_UP"),
+    second_runner_up: t.exposeInt("SECOND_RUNNER_UP"),
+  }),
+});
+
+const ChampionshipPoints = builder.objectType(ChampionshipPointsClass, {
+  name: "ChampionshipPoint",
+  fields: (t) => ({
+    id: t.exposeInt("collegeId"),
+    name: t.exposeString("collegeName"),
+    isEligible: t.exposeBoolean("isEligible"),
+    championshipPoints: t.exposeInt("championshipPoints"),
+    techCount: t.exposeInt("techCount"),
+    nonTechCount: t.exposeInt("nonTechCount"),
+    coreCount: t.exposeInt("coreCount"),
+    diamondCount: t.expose("diamondCount", {
+      type: Count,
+    }),
+    goldCount: t.expose("goldCount", {
+      type: Count,
+    }),
+    silverCount: t.expose("silverCount", {
+      type: Count,
+    }),
+    bronzeCount: t.expose("bronzeCount", {
+      type: Count,
+    }),
+  }),
+});
+
+builder.queryField("getChampionshipLeaderboard", (t) =>
+  t.field({
+    type: [ChampionshipPoints],
+    errors: {
+      types: [Error],
+    },
+    resolve: async (root, args, ctx, info) => {
+      const user = await ctx.user;
+      if (!user) {
+        throw new Error("Not authenticated");
+      }
+      if (user.role !== "JURY") {
+        throw new Error("Not authorized");
+      }
+
+      const colleges = await prisma.college.findMany();
+
+      const winners = await prisma.winners.findMany({
+        include: {
+          Team: {
+            select: {
+              leaderId: true,
+            },
+          },
+          Event: {
+            select: {
+              tier: true,
+              category: true,
+            },
+          },
+        },
+      });
+
+      const collegePoints = await Promise.all(
+        colleges.map(async (collegeItem) => {
+          const IsEligible = await checkChampionshipEligibility(collegeItem.id);
+          const eachCollegeData: ChampionshipPointsClass = {
+            collegeId: collegeItem.id,
+            isEligible: IsEligible,
+            collegeName: collegeItem.name,
+            championshipPoints: collegeItem.championshipPoints,
+            techCount: 0,
+            nonTechCount: 0,
+            coreCount: 0,
+            diamondCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+            goldCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+            silverCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+            bronzeCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+          };
+
+          const collegeWinners = (
+            await Promise.all(
+              winners.map(async (winner) => {
+                const leader = await ctx.prisma.user.findUnique({
+                  where: {
+                    id: winner.Team.leaderId ?? 0,
+                  },
+                });
+                return leader?.collegeId === collegeItem.id ? winner : null;
+              }),
+            )
+          ).filter((winner) => winner !== null);
+
+          collegeWinners.forEach((winner) => {
+            if (!winner.Event) return;
+
+            if (winner.Event.category === "TECHNICAL") {
+              eachCollegeData.techCount++;
+            } else if (winner.Event.category === "NON_TECHNICAL") {
+              eachCollegeData.nonTechCount++;
+            } else if (winner.Event.category === "CORE") {
+              eachCollegeData.coreCount++;
+            }
+
+            if (winner.Event.tier === "GOLD") {
+              eachCollegeData.goldCount[winner.type]++;
+            } else if (winner.Event.tier === "SILVER") {
+              eachCollegeData.silverCount[winner.type]++;
+            } else if (winner.Event.tier === "BRONZE") {
+              eachCollegeData.bronzeCount[winner.type]++;
+            } else if (winner.Event.tier === "DIAMOND") {
+              eachCollegeData.diamondCount[winner.type]++;
+            }
+          });
+          return eachCollegeData;
+        }),
+      );
+      return collegePoints;
     },
   }),
 );

--- a/src/graphql/models/Winner/utils.ts
+++ b/src/graphql/models/Winner/utils.ts
@@ -1,0 +1,91 @@
+import { prisma } from "~/utils/db";
+
+type Tier = "DIAMOND" | "GOLD" | "SILVER" | "BRONZE";
+type winnerType = "WINNER" | "RUNNER_UP" | "SECOND_RUNNER_UP";
+
+type PointsTable = {
+  [key in Tier]: {
+    [key in winnerType]: number;
+  };
+};
+
+const pointsTable: PointsTable = {
+  DIAMOND: {
+    WINNER: 600,
+    RUNNER_UP: 550,
+    SECOND_RUNNER_UP: 500,
+  },
+  GOLD: {
+    WINNER: 450,
+    RUNNER_UP: 400,
+    SECOND_RUNNER_UP: 350,
+  },
+  SILVER: {
+    WINNER: 300,
+    RUNNER_UP: 250,
+    SECOND_RUNNER_UP: 200,
+  },
+  BRONZE: {
+    WINNER: 150,
+    RUNNER_UP: 100,
+    SECOND_RUNNER_UP: 50,
+  },
+};
+
+const allocatePoints = (tier: Tier, winnerType: winnerType): number => {
+  return pointsTable[tier][winnerType];
+};
+
+const checkChampionshipEligibility = async (
+  collegeId: number,
+): Promise<boolean> => {
+  const finalRounds = await prisma.round.groupBy({
+    by: ["eventId"],
+    _max: { roundNo: true },
+  });
+
+  const eventFinalRoundMap = new Map(
+    finalRounds
+      .filter((round) => round._max.roundNo != null)
+      .map((round) => [round.eventId, round._max.roundNo!]),
+  );
+
+  const users = await prisma.user.findMany({
+    where: { collegeId: collegeId },
+    select: { id: true },
+  });
+
+  const leaderIds = users.map((user) => user.id);
+
+  const eligibilityTeams = await prisma.team.findMany({
+    where: {
+      leaderId: { in: leaderIds },
+      Event: {
+        published: true,
+        category: {
+          in: ["TECHNICAL", "NON_TECHNICAL"],
+        },
+        Rounds: {
+          some: {
+            roundNo: {
+              in: Array.from(eventFinalRoundMap.values()),
+            },
+          },
+        },
+      },
+    },
+    include: {
+      Event: true,
+    },
+  });
+
+  const techCount = eligibilityTeams.filter(
+    (team) => team.Event.category === "TECHNICAL",
+  ).length;
+  const nonTechCount = eligibilityTeams.filter(
+    (team) => team.Event.category === "NON_TECHNICAL",
+  ).length;
+  return techCount >= 3 && nonTechCount >= 2;
+};
+
+export { allocatePoints, checkChampionshipEligibility };


### PR DESCRIPTION
Add championshipPoints to College, EventTier to Event

Analytics queries:
- GetRevenue : calculates revenue by aggregating payment
- ProniteRegistrations : seperate count for day1 and day2
- ChampionshipLeaderboard
- Incridea Registrations : seperate count for internal and external
- Event Status : query to get the current status of the event

fix: eligiblity check in organizerAddTeamMembers 
- was checking the organizer's college instead of participant