### PR TITLE
[refactor] championshipLeaderboard query

### DIFF
--- a/src/graphql/models/Winner/utils.ts
+++ b/src/graphql/models/Winner/utils.ts
@@ -1,56 +1,95 @@
 import { prisma } from "~/utils/db";
 
-// TODO(Omkar): Might be too heavy of a query need refactor
-const checkChampionshipEligibility = async (
-  collegeId: number,
-): Promise<boolean> => {
+const getChampionshipEligibilityForAllColleges = async (): Promise<
+  Map<number, { isEligible: boolean; name: string; championshipPoints: number }>
+> => {
   const finalRounds = await prisma.round.groupBy({
     by: ["eventId"],
     _max: { roundNo: true },
   });
 
-  const eventFinalRoundMap = new Map(
+  const finalRoundMap = new Map(
     finalRounds
-      .filter((round) => round._max.roundNo != null)
+      .filter((round) => round._max.roundNo !== null)
       .map((round) => [round.eventId, round._max.roundNo!]),
   );
 
-  const users = await prisma.user.findMany({
-    where: { collegeId: collegeId },
-    select: { id: true },
-  });
-
-  const leaderIds = users.map((user) => user.id);
-
-  const eligibilityTeams = await prisma.team.findMany({
+  const eventParticipation = await prisma.team.findMany({
     where: {
-      leaderId: { in: leaderIds },
       Event: {
         published: true,
-        category: {
-          in: ["TECHNICAL", "NON_TECHNICAL"],
-        },
+        category: { in: ["TECHNICAL", "NON_TECHNICAL"] },
         Rounds: {
           some: {
-            roundNo: {
-              in: Array.from(eventFinalRoundMap.values()),
-            },
+            roundNo: { in: Array.from(finalRoundMap.values()) },
           },
         },
       },
     },
-    include: {
-      Event: true,
+    select: {
+      id: true,
+      Event: {
+        select: {
+          id: true,
+          category: true,
+        },
+      },
+      TeamMembers: {
+        select: {
+          User: {
+            select: { collegeId: true },
+          },
+        },
+      },
     },
   });
 
-  const techCount = eligibilityTeams.filter(
-    (team) => team.Event.category === "TECHNICAL",
-  ).length;
-  const nonTechCount = eligibilityTeams.filter(
-    (team) => team.Event.category === "NON_TECHNICAL",
-  ).length;
-  return techCount >= 3 && nonTechCount >= 2;
+  const collegeParticipationMap = new Map<
+    number,
+    { tech: number; nonTech: number }
+  >();
+
+  eventParticipation.forEach(({ TeamMembers, Event }) => {
+    TeamMembers.forEach(({ User }) => {
+      if (!User?.collegeId) return;
+
+      const collegeId = User.collegeId;
+      if (!collegeParticipationMap.has(collegeId)) {
+        collegeParticipationMap.set(collegeId, { tech: 0, nonTech: 0 });
+      }
+
+      const counts = collegeParticipationMap.get(collegeId)!;
+      if (Event.category === "TECHNICAL") counts.tech++;
+      if (Event.category === "NON_TECHNICAL") counts.nonTech++;
+    });
+  });
+
+  const colleges = await prisma.college.findMany({
+    select: {
+      id: true,
+      name: true,
+      championshipPoints: true,
+    },
+  });
+
+  const eligibilityMap = new Map<
+    number,
+    { isEligible: boolean; name: string; championshipPoints: number }
+  >();
+
+  colleges.forEach((college) => {
+    const counts = collegeParticipationMap.get(college.id) ?? {
+      tech: 0,
+      nonTech: 0,
+    };
+    eligibilityMap.set(college.id, {
+      isEligible: counts.tech >= 3 && counts.nonTech >= 2,
+      name: college.name,
+      championshipPoints: college.championshipPoints,
+    });
+  });
+
+  return eligibilityMap;
 };
 
-export { checkChampionshipEligibility };
+export { getChampionshipEligibilityForAllColleges };


### PR DESCRIPTION
before leaderboard query was fetching each college for which the eligibilty check was done fetching rounds again and again
now eligibility check is fetching all colleges and updating the eligibilty status and returning a map. with the championship points.

Fetching users is removed, checking the collegeID with Team members

