### PR TITLE
refac event status, championshipPoints query

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,6 +7,7 @@ import { AVATARS } from "~/constants/avatars";
 import { type Avatar } from "~/constants/type";
 
 const CONSTANT = {
+  INTERNAL_COLLEGE_ID: 1 as const,
   REG_AMOUNT_IN_INR: {
     INTERNAL: 350,
     EXTERNAL: 450,

--- a/src/graphql/models/User/query.ts
+++ b/src/graphql/models/User/query.ts
@@ -123,7 +123,7 @@ builder.queryField("getTotalRegistrations", (t) =>
               // Internal participant might be anything excpet these roles
               notIn: ["JUDGE", "USER"],
             },
-            collegeId: 1,
+            collegeId: CONSTANT.INTERNAL_COLLEGE_ID,
             ...(args.date
               ? {
                 createdAt: {
@@ -150,7 +150,7 @@ builder.queryField("getTotalRegistrations", (t) =>
               in: ["PARTICIPANT"],
             },
             collegeId: {
-              not: 1,
+              not: CONSTANT.INTERNAL_COLLEGE_ID,
             },
             ...(args.date
               ? {


### PR DESCRIPTION
shortened the message, refactored cases where round 1 completed but round 2 didn't start.

Refactored championship Points query which now fetches CollegeId within the winners query eliminating fetching users then mapping with leader id.